### PR TITLE
Add Ollama support as a model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Local Agent logo](local-agent.png)
 
 An edge agent framework built in pure Python.
-- Connects to local language model servers: [AnythingLLM](https://anythingllm.com), [LM Studio](https://lmstudio.ai), and [Nexa](https://nexa.ai)
+- Connects to local language model servers: [AnythingLLM](https://anythingllm.com), [LM Studio](https://lmstudio.ai), [Nexa](https://nexa.ai), and [Ollama](https://ollama.com)
 - Easily extensible with custom tools
 
 ## Quick Start

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,32 @@
+# Local Agent Configuration File
+# Copy this file to config.yaml and adjust the values for your setup
+
+# General variables
+MODEL_PROVIDER: "ollama"  # options: anythingllm, lmstudio, nexa, ollama
+STREAM: False  # not working, do not use yet (or submit a PR!)
+STREAM_TIMEOUT: 30
+
+# Memory settings
+SHORT_MEMORY_SIZE: 20  # messages
+LONG_MEMORY_SIZE: 5096  # tokens
+DISABLE_SHORT_MEMORY: False
+DISABLE_LONG_MEMORY: True # not working, do not use yet (or submit a PR!)
+
+# AnythingLLM configuration
+ANYTHINGLLM_API_KEY: "your-api-key"
+ANYTHINGLLM_WORKSPACE: "local-agent"
+ANYTHINGLLM_URL: "http://localhost:3001/api/v1"
+
+# LM Studio configuration
+LM_STUDIO_API_KEY: "lm-studio" # placeholder, not used
+LM_STUDIO_MODEL: "hugging-quants/llama-3.2-3b-instruct"
+LM_STUDIO_URL: "http://localhost:1234/v1"
+
+# Nexa configuration
+NEXA_API_KEY: "nexa" # placeholder, configured in the sdk
+NEXA_URL: "http://127.0.0.1:18181/v1/chat/completions"
+
+# Ollama configuration
+OLLAMA_API_KEY: "ollama" # placeholder, not required
+OLLAMA_MODEL: "llama3.2:3b"
+OLLAMA_URL: "http://localhost:11434/v1"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Use this guide to setup and configure the Local Agent with your choice of local 
 
    ```yaml
    # general variables
-    MODEL_PROVIDER: "your-provider-here"  # options: anythingllm, lmstudio, nexa
+    MODEL_PROVIDER: "your-provider-here"  # options: anythingllm, lmstudio, nexa, ollama
     STREAM: False  # not working, do not use yet (or submit a PR!)
     STREAM_TIMEOUT: 30
     
@@ -41,6 +41,11 @@ Use this guide to setup and configure the Local Agent with your choice of local 
     # Nexa configuration
     NEXA_API_KEY: "nexa" # placeholder, configured in the sdk
     NEXA_URL: "http://127.0.0.1:18181/v1/chat/completions"
+
+    # Ollama configuration
+    OLLAMA_API_KEY: "ollama" # placeholder, not required
+    OLLAMA_MODEL: "gemma3:27b"
+    OLLAMA_URL: "http://localhost:11434/v1"
    ```
    Adjust the values as needed for the providers you want to use, sensible defaults have been chosen.
    
@@ -58,6 +63,7 @@ Use this guide to setup and configure the Local Agent with your choice of local 
 - [AnythingLLM Backend Instructions](anythingllm_setup.md)
 - [LM Studio Backend Instructions](lmstudio_setup.md)
 - [Nexa Backend Instructions](nexa_setup.md)
+- [Ollama Backend Instructions](ollama_setup.md)
 
 ---
 
@@ -70,6 +76,7 @@ Run the tests from the base directory to verify your setup:
 # -c: Core tests
 # -l: LM Studio
 # -n: Nexa  # ARM64 Windows only
+# -o: Ollama
 
 # Windows PowerShell (running all tests)
 .\scripts\run_tests.ps1 

--- a/docs/ollama_setup.md
+++ b/docs/ollama_setup.md
@@ -1,0 +1,86 @@
+# Ollama Backend
+
+Before following these steps, ensure you have completed the initial [Setup Guide](README.md).
+
+## Requirements
+
+- Python 3.8+
+- `openai` and `pyyaml` Python packages
+- Ollama installed and running on your system
+
+## Setup Instructions
+
+1. **Install Ollama**
+
+   - Download and install [Ollama](https://ollama.ai) for your operating system:
+     - **macOS/Linux**: Run `curl -fsSL https://ollama.com/install.sh | sh`
+     - **Windows**: Download from [https://ollama.com/download](https://ollama.com/download)
+   - Or visit the official website for manual installation instructions.
+
+2. **Start Ollama Service**
+
+   - Ollama typically runs as a background service after installation
+   - To verify it's running, open a terminal and run:
+     ```sh
+     ollama list
+     ```
+   - This should show installed models (if any) without errors
+
+3. **Download and Run a Model**
+
+   - Pull a model using the Ollama CLI. For example, to download Llama 3.2 3B:
+     ```sh
+     ollama pull llama3.2:3b
+     ```
+   - Other recommended models:
+     - `llama3.2:1b` - Smallest, fastest (1.3GB)
+     - `llama3.2:3b` - Balanced performance (2GB)
+     - `mistral:7b` - Larger, more capable (4.1GB)
+     - `phi3:mini` - Efficient small model (2.3GB)
+   
+4. **Configure Your Application**
+
+   - Create a `config.yaml` file in the project root with the following settings:
+     ```yaml
+     MODEL_PROVIDER: "ollama"
+     OLLAMA_URL: "http://localhost:11434/v1"
+     OLLAMA_API_KEY: "ollama"  # Can be any value; Ollama doesn't require auth by default
+     OLLAMA_MODEL: "llama3.2:3b"  # Use the model name you pulled
+     
+     # Memory settings
+     SHORT_MEMORY_SIZE: 20
+     LONG_MEMORY_SIZE: 5096
+     DISABLE_SHORT_MEMORY: False
+     DISABLE_LONG_MEMORY: True
+     STREAM: False
+     STREAM_TIMEOUT: 30
+     ```
+
+5. **Verify the Setup**
+
+   - Test that Ollama is responding:
+     ```sh
+     curl http://localhost:11434/api/tags
+     ```
+   - This should return a JSON list of installed models
+
+## Troubleshooting
+
+- **Port Already in Use**: Ollama uses port 11434 by default. If it's in use, you can change the port by setting the `OLLAMA_HOST` environment variable:
+  ```sh
+  export OLLAMA_HOST=0.0.0.0:11435
+  ```
+  Then update `OLLAMA_URL` in your `config.yaml` accordingly.
+
+- **Model Not Found**: Ensure you've pulled the model using `ollama pull <model-name>` before running the application.
+
+- **Connection Refused**: Make sure the Ollama service is running. On macOS/Linux, you can restart it with:
+  ```sh
+  ollama serve
+  ```
+
+## API Compatibility
+
+Ollama provides an OpenAI-compatible API endpoint at `http://localhost:11434/v1`, which this application uses. This means you can use the same Python `openai` package to interact with Ollama models.
+
+Return to the [Testing](README.md#testing) and [Usage](README.md#usage) sections in the [Setup Guide](README.md) to verify your setup and run the local agent.

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -2,10 +2,11 @@ param(
     [switch]$a,
     [switch]$c,
     [switch]$l,
-    [switch]$n
+    [switch]$n,
+    [switch]$o
 )
 
-Write-Host "Please start the required backend servers (AnythingLLM, LMStudio, Nexa) manually."
+Write-Host "Please start the required backend servers (AnythingLLM, LMStudio, Nexa, Ollama) manually."
 Write-Host "Press Enter when complete."
 Read-Host
 
@@ -14,17 +15,18 @@ Read-Host
 Set-Location $PSScriptRoot\..
 
 $tests = @()
-if ($a -or (-not $a -and -not $c -and -not $l -and -not $n)) { $tests += "tests/test_anythingllm.py" }
-if ($c -or (-not $a -and -not $c -and -not $l -and -not $n)) {
+if ($a -or (-not $a -and -not $c -and -not $l -and -not $n -and -not $o)) { $tests += "tests/test_anythingllm.py" }
+if ($c -or (-not $a -and -not $c -and -not $l -and -not $n -and -not $o)) {
     $tests += "tests/core/test_agent.py"
     $tests += "tests/core/test_model.py"
     $tests += "tests/core/test_tools.py"
 }
-if ($l -or (-not $a -and -not $c -and -not $l -and -not $n)) { $tests += "tests/test_lmstudio.py" }
-if ($n -or (-not $a -and -not $c -and -not $l -and -not $n)) { $tests += "tests/test_nexa.py" }
+if ($l -or (-not $a -and -not $c -and -not $l -and -not $n -and -not $o)) { $tests += "tests/test_lmstudio.py" }
+if ($n -or (-not $a -and -not $c -and -not $l -and -not $n -and -not $o)) { $tests += "tests/test_nexa.py" }
+if ($o -or (-not $a -and -not $c -and -not $l -and -not $n -and -not $o)) { $tests += "tests/test_ollama.py" }
 
 if ($tests.Count -eq 0) {
-    $tests = @("tests/test_anythingllm.py", "tests/test_lmstudio.py", "tests/test_nexa.py", "tests/core/test_agent.py", "tests/core/test_model.py", "tests/core/test_tools.py")
+    $tests = @("tests/test_anythingllm.py", "tests/test_lmstudio.py", "tests/test_nexa.py", "tests/test_ollama.py", "tests/core/test_agent.py", "tests/core/test_model.py", "tests/core/test_tools.py")
 }
 
 Write-Host "Running pytest for: $($tests -join ', ')"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-# Usage: ./run_tests.sh [-a] [-l]
+# Usage: ./run_tests.sh [-a] [-c] [-l] [-o]
 # -a: Run AnythingLLM tests only
 # -c: Run core tests only
 # -l: Run LMStudio tests only
+# -o: Run Ollama tests only
 
 set -e
 
 # Prompt user to start backend servers
 cat <<EOF
-Please start the required backend servers (AnythingLLM, LMStudio, Nexa) manually.
+Please start the required backend servers (AnythingLLM, LMStudio, Nexa, Ollama) manually.
 Press Enter when complete.
 EOF
 read
@@ -22,27 +23,30 @@ cd "$SCRIPT_DIR/.."
 a_flag=false
 c_flag=false
 l_flag=false
-while getopts "acl" opt; do
+o_flag=false
+while getopts "aclo" opt; do
   case $opt in
     a) a_flag=true ;;
     c) c_flag=true ;;
     l) l_flag=true ;;
+    o) o_flag=true ;;
     *) ;;
   esac
 done
 
 # Determine tests to run
 tests=()
-if $a_flag || (! $a_flag && ! $c_flag && ! $l_flag); then tests+=("tests/test_anythingllm.py"); fi
-if $c_flag || (! $a_flag && ! $c_flag && ! $l_flag); then
+if $a_flag || (! $a_flag && ! $c_flag && ! $l_flag && ! $o_flag); then tests+=("tests/test_anythingllm.py"); fi
+if $c_flag || (! $a_flag && ! $c_flag && ! $l_flag && ! $o_flag); then
   tests+=("tests/core/test_agent.py")
   tests+=("tests/core/test_model.py")
   tests+=("tests/core/test_tools.py")
 fi
-if $l_flag || (! $a_flag && ! $c_flag && ! $l_flag); then tests+=("tests/test_lmstudio.py"); fi
+if $l_flag || (! $a_flag && ! $c_flag && ! $l_flag && ! $o_flag); then tests+=("tests/test_lmstudio.py"); fi
+if $o_flag || (! $a_flag && ! $c_flag && ! $l_flag && ! $o_flag); then tests+=("tests/test_ollama.py"); fi
 
 if [ ${#tests[@]} -eq 0 ]; then
-  tests=("tests/test_anythingllm.py" "tests/test_lmstudio.py" "tests/core/test_agent.py" "tests/core/test_model.py" "tests/core/test_tools.py")
+  tests=("tests/test_anythingllm.py" "tests/test_lmstudio.py" "tests/test_ollama.py" "tests/core/test_agent.py" "tests/core/test_model.py" "tests/core/test_tools.py")
 fi
 
 echo "Running pytest for: ${tests[*]}"

--- a/src/model.py
+++ b/src/model.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Any
 from src.servers.anythingllm import setup_anythingllm_client # , anythingllm_chat_completion
 from src.servers.lmstudio import setup_lm_studio_client # , lmstudio_chat_completion
 from src.servers.nexa import setup_nexa_client # , nexa_chat_completion
+from src.servers.ollama import setup_ollama_client
 
 # A message is a dictionary with a role and content
 Message = Dict[str, str]
@@ -29,6 +30,8 @@ class ModelInterface:
             return setup_lm_studio_client(config)
         elif self.model_provider.lower() == "nexa":
             return setup_nexa_client(config)
+        elif self.model_provider.lower() == "ollama":
+            return setup_ollama_client(config)
         else:
             raise ValueError(f"Unsupported MODEL_PROVIDER: {self.model_provider}")
 
@@ -74,5 +77,9 @@ class ModelInterface:
             #     temperature=temperature,
             #     stream=stream
             # )
+        elif self.model_provider.lower() == "ollama":
+            if stream:
+                return self.client.streaming_chat(messages, temperature=temperature)
+            return self.client.chat(messages, temperature=temperature)
         else:
             raise ValueError(f"Unsupported MODEL_PROVIDER: {self.model_provider}")

--- a/src/servers/ollama.py
+++ b/src/servers/ollama.py
@@ -1,0 +1,32 @@
+from typing import List, Dict, Any
+from openai import OpenAI
+
+class OllamaClient:
+    def __init__(self, config: Dict[str, Any]):
+        self.api_key = config.get("OLLAMA_API_KEY", "ollama")
+        self.base_url = config.get("OLLAMA_URL", "http://localhost:11434/v1")
+        self.model = config.get("OLLAMA_MODEL", "llama3.2:3b")
+
+        self.client = OpenAI(base_url=self.base_url, api_key=self.api_key)
+
+    def chat(self, messages: List[Dict[str, str]], temperature: float = 0.7) -> str:
+        """Send a blocking chat request to the Ollama model and return the response."""
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=temperature
+        )
+        return resp.choices[0].message.content
+    
+    def streaming_chat(self, messages: List[Dict[str, str]], temperature: float = 0.7):
+        return self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=temperature,
+            stream=True
+        )
+
+def setup_ollama_client(
+    config: Dict[str, Any]
+) -> OllamaClient:
+    return OllamaClient(config)

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,28 @@
+import pytest
+import yaml
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.servers.ollama import OllamaClient
+
+def load_config():
+    with open("config.yaml", "r") as f:
+        return yaml.safe_load(f)
+
+CONFIG = load_config()
+
+def test_server_running():
+    import requests
+    url = f"{CONFIG['OLLAMA_URL'].replace('/v1', '')}/api/tags"
+    try:
+        response = requests.get(url, timeout=30)
+        assert response.status_code == 200
+    except Exception as e:
+        pytest.fail(f"Ollama server not running or unreachable: {e}")
+
+def test_chat_endpoint():
+    client = OllamaClient(CONFIG)
+    messages = [{"role": "user", "content": "Hello, Ollama!"}]
+    reply = client.chat(messages)
+    assert isinstance(reply, str)
+    assert reply


### PR DESCRIPTION
- Add OllamaClient implementation using OpenAI-compatible API
- Add Ollama integration to ModelInterface with streaming support
- Add comprehensive Ollama setup documentation
- Add Ollama integration tests
- Update test scripts to include Ollama test flag (-o)
- Add config.yaml.example with Ollama configuration
- Update README to list Ollama as a supported backend

Ollama provides a simple way to run LLMs locally with an OpenAI-compatible API endpoint. This implementation supports both standard and streaming chat completions.